### PR TITLE
Sanitize and return metadata along with the data span

### DIFF
--- a/mp4san/src/lib.rs
+++ b/mp4san/src/lib.rs
@@ -19,7 +19,7 @@ pub enum Error {
 }
 
 pub struct SanitizedMetadata {
-    pub metadata: Box<[u8]>,
+    pub metadata: Vec<u8>,
     pub data: InputSpan,
 }
 
@@ -153,16 +153,13 @@ pub fn sanitize<R: Read + Seek>(input: R) -> Result<SanitizedMetadata, Error> {
         }
     }
 
-    let metadata = {
-        let mut metadata = Vec::with_capacity((metadata_len + pad_size) as usize);
-        ftyp.write_box(&mut metadata)?;
-        moov.write_box(&mut metadata)?;
-        if pad_size != 0 {
-            BoxHeader { name: BoxType::FreeBox, size: pad_size }.write(&mut metadata)?;
-            metadata.resize((metadata_len + pad_size) as usize, 0);
-        }
-        metadata.into_boxed_slice()
-    };
+    let mut metadata = Vec::with_capacity((metadata_len + pad_size) as usize);
+    ftyp.write_box(&mut metadata)?;
+    moov.write_box(&mut metadata)?;
+    if pad_size != 0 {
+        BoxHeader { name: BoxType::FreeBox, size: pad_size }.write(&mut metadata)?;
+        metadata.resize((metadata_len + pad_size) as usize, 0);
+    }
 
     Ok(SanitizedMetadata { metadata, data })
 }


### PR DESCRIPTION
We return sanitized metadata to be concatenated with the media data, which located in the input stream using the returned data span. This 1) will ensure the resulting media is streamable (since all the metadata will be at the beginning), and 2) allows us to sanitize the metadata in any way we want before we return it to the caller. I believe metadata length should always be small enough to reasonably return in a `Vec`, on the order of tens of kilobytes, but we should verify this.

To keep the API simple, we currently require all `mdat` to be contiguous or separated only by `free` boxes, since any sane MP4 file should really only have a single `mdat`, but if this really turns out to be an issue, we can instead return multiple data spans for concatenation.

We also try to pad sanitized metadata in the case that the media data would otherwise move backward, to open the possibility for the caller to simply overwrite existing metadata instead of rewriting the entire file.