### PR TITLE
Fix disabling `error-stack/std` on nightly

### DIFF
--- a/mp4san/Cargo.toml
+++ b/mp4san/Cargo.toml
@@ -14,10 +14,6 @@ keywords = ["mp4", "sanitizer", "video", "media"]
 readme = "../README.md"
 exclude = ["/.github", ".*", "tests/test-data/"]
 
-[features]
-default = ["error-stack-std"]
-error-stack-std = ["error-stack/std"]
-
 [dependencies]
 bytes = "1.3.0"
 derive-where = "1.1.0"

--- a/mp4san/Cargo.toml
+++ b/mp4san/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mp4san"
 description = "An MP4 file sanitizer."
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 
 rust-version = "1.61.0"


### PR DESCRIPTION
mp4san-0.2.0 allows leaving error-stack/std disabled on both stable and nightly, so use that.
