### PR TITLE
Centralize dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,36 @@ repository = "https://github.com/privacyresearchgroup/mp4san"
 license = "MIT"
 
 exclude = ["/.github", ".*", "/test-data/"]
+
+[workspace.dependencies]
+ac-ffmpeg = "0.18.1"
+afl = "0.12.16"
+anyhow = "1.0.68"
+assert_matches = "1.5.0"
+bindgen = "0.69.4"
+bitflags = "2.4.0"
+bitstream-io = "1.7.0"
+bytes = "1.3.0"
+cc = "1.0.79"
+clap = "4.0.32"
+criterion = "0.5.1"
+derive-where = "1.1.0"
+derive_builder = "0.20.2"
+derive_more = "0.99.17"
+downcast-rs = "1.2.0"
+dyn-clonable = "0.9.0"
+env_logger = "0.11.3"
+ffmpeg-sys-next = { version = "7.0.0", default-features = false }
+futures-util = { version = "0.3.28", default-features = false }
+libflate = "2.1.0"
+libwebp-sys = "0.9.4"
+log = "0.4.17"
+num-integer = { version = "0.1.45", default-features = false }
+num-traits = { version = "0.2.16", default-features = false }
+paste = "1.0.14"
+pkg-config = "0.3.26"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "2.0"
+thiserror = "1.0.38"
+uuid = "1.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 publish = false
 
 [dependencies]
-anyhow = "1.0.68"
-clap = { version = "4.0.32", features = ["derive"] }
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 mp4san = { path = "../mp4san" }
 webpsan = { path = "../webpsan" }
-env_logger = "0.11.3"
-log = "0.4.17"
+env_logger = { workspace = true }
+log = { workspace = true }

--- a/common-test/Cargo.toml
+++ b/common-test/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 publish = false
 
 [dependencies]
-env_logger = "0.11.3"
-libflate = "2.1.0"
-log = "0.4.17"
+env_logger = { workspace = true }
+libflate = { workspace = true }
+log = { workspace = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 exclude.workspace = true
 
 [dependencies]
-bytes = "1.3.0"
-derive_more = "0.99.17"
-futures-util = { version = "0.3.28", default-features = false, features = ["io"] }
-thiserror = "1.0.38"
+bytes = { workspace = true }
+derive_more = { workspace = true }
+futures-util = { workspace = true, features = ["io"] }
+thiserror = { workspace = true }

--- a/mp4san-derive/Cargo.toml
+++ b/mp4san-derive/Cargo.toml
@@ -18,7 +18,7 @@ exclude.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-syn = "2.0"
-quote = "1.0"
-uuid = "1.3"
+proc-macro2 = { workspace = true }
+syn = { workspace = true }
+quote = { workspace = true }
+uuid = { workspace = true }

--- a/mp4san-test-gen/Cargo.toml
+++ b/mp4san-test-gen/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 publish = false
 
 [dependencies]
-anyhow = "1.0.68"
-clap = { version = "4.0.32", features = ["derive"] }
-env_logger = "0.11.3"
-libflate = "2.1.0"
-log = "0.4.17"
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+env_logger = { workspace = true }
+libflate = { workspace = true }
+log = { workspace = true }
 mp4san = { path = "../mp4san" }

--- a/mp4san-test/Cargo.toml
+++ b/mp4san-test/Cargo.toml
@@ -11,12 +11,12 @@ ffmpeg = ["dep:ac-ffmpeg", "dep:bindgen", "dep:cc", "dep:ffmpeg-sys-next"]
 gpac = ["dep:bindgen", "dep:cc", "dep:pkg-config"]
 
 [dependencies]
-ac-ffmpeg = { version = "0.18.1", optional = true }
-ffmpeg-sys-next = { version = "7.0.0", default-features = false, features = ["avformat"], optional = true }
-log = "0.4.17"
-thiserror = "1.0.40"
+ac-ffmpeg = { workspace = true, optional = true }
+ffmpeg-sys-next = { workspace = true, default-features = false, features = ["avformat"], optional = true }
+log = { workspace = true }
+thiserror = { workspace = true }
 
 [build-dependencies]
-bindgen = { version = "0.69.4", optional = true }
-cc = { version = "1.0.79", optional = true }
-pkg-config = { version = "0.3.26", optional = true }
+bindgen = { workspace = true, optional = true }
+cc = { workspace = true, optional = true }
+pkg-config = { workspace = true, optional = true }

--- a/mp4san/Cargo.toml
+++ b/mp4san/Cargo.toml
@@ -15,20 +15,20 @@ readme = "README.md"
 exclude.workspace = true
 
 [dependencies]
-bytes = "1.3.0"
-derive-where = "1.1.0"
-derive_builder = "0.20.2"
-derive_more = "0.99.17"
-downcast-rs = "1.2.0"
-dyn-clonable = "0.9.0"
-futures-util = { version = "0.3.28", default-features = false, features = ["io"] }
-log = "0.4.17"
+bytes = { workspace = true }
+derive-where = { workspace = true }
+derive_builder = { workspace = true }
+derive_more = { workspace = true }
+downcast-rs = { workspace = true }
+dyn-clonable = { workspace = true }
+futures-util = { workspace = true, features = ["io"] }
+log = { workspace = true }
 mediasan-common = { path = "../common", version = "=0.5.3" }
 mp4san-derive = { path = "../mp4san-derive", version = "=0.5.3" }
-paste = "1.0.14"
-thiserror = "1.0.38"
+paste = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 mediasan-common-test = { path = "../common-test" }
 mp4san-test = { path = "../mp4san-test" }

--- a/webpsan-test/Cargo.toml
+++ b/webpsan-test/Cargo.toml
@@ -10,6 +10,6 @@ default = []
 libwebp = ["dep:libwebp-sys"]
 
 [dependencies]
-libwebp-sys = { version = "0.9.4", optional = true }
-log = "0.4.17"
-thiserror = "1.0.40"
+libwebp-sys = { workspace = true, optional = true }
+log = { workspace = true }
+thiserror = { workspace = true }

--- a/webpsan/Cargo.toml
+++ b/webpsan/Cargo.toml
@@ -19,21 +19,21 @@ default = ["error-detail"]
 error-detail = []
 
 [dependencies]
-assert_matches = "1.5.0"
-bitflags = "2.4.0"
-bitstream-io = "1.7.0"
-bytes = "1.3.0"
-derive_builder = "0.20.0"
-derive_more = "0.99.17"
-log = "0.4.17"
+assert_matches = { workspace = true }
+bitflags = { workspace = true }
+bitstream-io = { workspace = true }
+bytes = { workspace = true }
+derive_builder = { workspace = true }
+derive_more = { workspace = true }
+log = { workspace = true }
 mediasan-common = { path = "../common", version = "=0.5.3" }
-num-integer = { version = "0.1.45", default-features = false }
-num-traits = { version = "0.2.16", default-features = false }
-thiserror = "1.0.38"
+num-integer = { workspace = true }
+num-traits = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-criterion = { version = "0.5.1", features = ["async_futures"] }
+assert_matches = { workspace = true }
+criterion = { workspace = true, features = ["async_futures"] }
 mediasan-common-test = { path = "../common-test" }
 webpsan-test = { path = "../webpsan-test" }
 


### PR DESCRIPTION
Specify the versions for all dependencies in one place. This will make it easier to update versions of dependencies without having to change too many places.